### PR TITLE
Speed up feature specs by skipping sign in

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+require "devise_back_door"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -39,4 +41,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.middleware.use DeviseBackDoor
 end

--- a/lib/devise_back_door.rb
+++ b/lib/devise_back_door.rb
@@ -1,0 +1,25 @@
+class DeviseBackDoor
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @env = env
+    sign_in_through_the_back_door
+    @app.call(env)
+  end
+
+  private
+
+  def sign_in_through_the_back_door
+    user_id = params["as"]
+
+    if user_id.present?
+      @env["warden"].set_user User.find(user_id), scope: :user
+    end
+  end
+
+  def params
+    Rack::Utils.parse_query(@env["QUERY_STRING"])
+  end
+end

--- a/spec/features/pages/user_creates_a_page_spec.rb
+++ b/spec/features/pages/user_creates_a_page_spec.rb
@@ -3,23 +3,15 @@ require "rails_helper"
 feature "Creates a Page" do
   scenario "authenticated" do
     user = create(:user)
-    sign_in user
 
     visit pages_path(as: user)
 
     fill_in "Title", with: "About Me"
     fill_in "Url Key", with: "about-me"
-    fill_in "Description", with: "I am a philosiphizer"
+    fill_in "Body", with: "I am a philosiphizer"
     click_button "Create Page"
 
     expect(page).to have_text("Page Saved")
     expect(Page.last.title).to eq("About Me")
-  end
-
-  def sign_in(user)
-    visit new_user_session_path
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Sign in"
   end
 end

--- a/spec/features/projects/user_creates_a_project_spec.rb
+++ b/spec/features/projects/user_creates_a_project_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 feature "Creates a Project" do
   scenario "authenticated" do
     user = create(:user)
-    sign_in user
 
     project = build(:project)
     visit new_project_path(as: user)
@@ -15,12 +14,5 @@ feature "Creates a Project" do
 
     expect(page).to have_text(project.title)
     expect(Project.last.title).to eq(project.title)
-  end
-
-  def sign_in(user)
-    visit new_user_session_path
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Sign in"
   end
 end

--- a/spec/features/projects/user_views_a_project_spec.rb
+++ b/spec/features/projects/user_views_a_project_spec.rb
@@ -11,7 +11,6 @@ feature "User views a Project" do
 
   scenario "user creates project" do
     user = create(:user)
-    sign_in user
 
     project = build(:project)
     visit new_project_path(as: user)
@@ -23,12 +22,5 @@ feature "User views a Project" do
 
     expect(page).to have_text(project.title)
     expect(Project.last.title).to eq(project.title)
-  end
-
-  def sign_in(user)
-    visit new_user_session_path
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Sign in"
   end
 end

--- a/spec/features/user_edits_a_page_spec.rb
+++ b/spec/features/user_edits_a_page_spec.rb
@@ -10,7 +10,6 @@ feature "Edits a Page" do
   scenario "authenticated as a user under different domain" do
     page_owner = create(:user)
     create(:page, user: page_owner)
-    sign_in(page_owner)
     page_owner.update_attribute(:domain, "wrong_domain_for_test")
 
     visit pages_path(as: page_owner)
@@ -21,18 +20,10 @@ feature "Edits a Page" do
   scenario "authenticated user at correct domain" do
     user = create(:user)
     nice_page = create(:page, user: user)
-    sign_in(user)
 
     visit pages_path(as: user)
 
     expect(page).to have_text(nice_page.body)
     expect(page).to have_button("Update Page")
-  end
-
-  def sign_in(user)
-    visit new_user_session_path
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Sign in"
   end
 end


### PR DESCRIPTION
No need to visit sign_in path, fill in fields, and click button to
create a session. Instead, we create some custom middleware for the
testing environment:
https://robots.thoughtbot.com/faster-tests-sign-in-through-the-back-door