### PR TITLE
Send less requests to server for markdown preview

### DIFF
--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -2,6 +2,8 @@ $(function(){
   var $message = $("#page_body");
   var $previewBox = $(".welcome");
   var previewPlaceholder = $previewBox.html()
+  var lastResponseMarkdown = previewPlaceholder;
+  var lastTextSent = $message.val();
 
   $message.keyup(function(){
     delay(preview, 1000);
@@ -17,14 +19,18 @@ $(function(){
 
   var preview = function(){
     var message = $message.val();
-    if (message) {
+    if (!message) {
+      displayMessage(previewPlaceholder);
+    } else if (message !== lastTextSent) {
+      lastTextSent = message;
       $.post("/previews", { preview: message }, displayMessage);
     } else {
-      displayMessage(previewPlaceholder);
+      displayMessage(lastResponseMarkdown);
     };
   };
 
   var displayMessage = function(text){
+    lastResponseMarkdown = text;
     $previewBox.html(text);
   };
 });


### PR DESCRIPTION
This prevents requests to the server if the next text to check was the
last text checked. In other words, the last response is saved, but
discarded after the input field actually changes.

More elaborate caching would not be difficult. Perhaps a number of
responses could be cached.