### PR TITLE
Styling changes mainly for logged in users

### DIFF
--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -1,6 +1,6 @@
 $(function(){
   var $message = $("#page_body");
-  var $previewBox = $(".welcome");
+  var $previewBox = $(".page-body");
   var previewPlaceholder = $previewBox.html()
   var lastResponseMarkdown = previewPlaceholder;
   var lastTextSent = $message.val();

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 @import "shared/base";
+@import "dialogue";
 @import "welcome";
 @import "pages";
 @import "user_menu";

--- a/app/assets/stylesheets/dialogue.scss
+++ b/app/assets/stylesheets/dialogue.scss
@@ -1,0 +1,6 @@
+@import "shared/variables";
+
+.dialogue {
+  display: block;
+  height: $text-size;
+}

--- a/app/assets/stylesheets/shared/base.scss
+++ b/app/assets/stylesheets/shared/base.scss
@@ -12,3 +12,7 @@ input,
 .form-control {
   height: 2 * $font-size;
 }
+
+h1 {
+  text-align: center;
+}

--- a/app/assets/stylesheets/shared/variables.scss
+++ b/app/assets/stylesheets/shared/variables.scss
@@ -1,1 +1,2 @@
 $desktop-screen: "only screen and (min-width: 601px)" !default;
+$text-size: 65px;

--- a/app/assets/stylesheets/welcome.css.scss
+++ b/app/assets/stylesheets/welcome.css.scss
@@ -2,8 +2,6 @@
 @import "shared/variables";
 
 .welcome {
-  $text-size: 65px;
-  margin-top: $text-size;
   text-align: center;
 
   div, li, ul, a, p {

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -1,10 +1,22 @@
 <div class="user-menu">
-  <ul class="nav nav-pills">
-    <li><%= link_to "logout", destroy_user_session_path, method: :delete %></li>
-    <li><%= link_to "Main Menu", root_url %></li>
-    <li><%= link_to "Edit Menu", pages_url %></li>
-    <li><%= link_to "New Project", new_project_url %></li>
-    <li><%= link_to "All Projects", projects_url %></li>
-    <li><%= link_to "Change Domain", edit_user_path(current_user) %></li>
+  <ul class="nav">
+    <li class="col-xs-4 col-lg-2">
+      <%= link_to "logout", destroy_user_session_path, method: :delete %>
+    </li>
+    <li class="col-xs-4 col-lg-2">
+      <%= link_to "Main Menu", root_url %>
+    </li>
+    <li class="col-xs-4 col-lg-2">
+      <%= link_to "Edit Menu", pages_url %>
+    </li>
+    <li class="col-xs-4 col-lg-2">
+      <%= link_to "New Project", new_project_url %>
+    </li>
+    <li class="col-xs-4 col-lg-2">
+      <%= link_to "All Projects", projects_url %>
+    </li>
+    <li class="col-xs-4 col-lg-2">
+      <%= link_to "Domains", edit_user_path(current_user) %>
+    </li>
   </ul>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,9 +11,12 @@
   </head>
   <body>
     <div class="container-fluid">
-      <div class="center container-fluid">
+      <div class="col-lg-10 col-lg-offset-1">
         <% if current_user %>
           <%= render partial: "layouts/user_menu" %>
+          <div class="dialogue container-fluid">
+            <%= yield :dialogue %>
+          </div>
         <% end %>
 
         <% if flash[:errors] %>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -1,7 +1,9 @@
-<h1>Edit <%= @page.title %></h1>
+<% content_for :dialogue do %>
+  <h1>Edit <%= @page.title %></h1>
+<% end %>
 <%= render partial: "page_form", locals: { page: @page } %>
 <%= button_to "delete", page_url(@page), method: :delete, class: "pull-right" %>
 <div class="welcome">
-  <%= MarkdownHelper.new(@page.body).render %>
+  <%= render partial: "shared/page_content", locals: { page: @page } %>
 </div>
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,12 +1,22 @@
-<h1>Click to Edit</h1>
+<div class="edit-index">
+  <%= content_for :dialogue do %>
+    <h1>Click to Edit</h1>
+  <% end %>
 
-<% @pages.each do |page| %>
-  <div>
-    <%= link_to(
-      page.title,
-      edit_page_url(page),
-    ) %>
+  <div class="welcome container-fluid">
+    <ul class="pages nav nav-stacked">
+      <% @pages.each do |page| %>
+        <li>
+          <%= link_to(
+            page.title,
+            edit_page_url(page)
+          ) %>
+        </li>
+      <% end %>
+
+      <li>
+        <%= link_to "New Page", new_page_path  %>
+      </li>
+    </ul>
   </div>
-<% end %>
-
-<%= link_to "New Page", new_page_path %>
+</div>

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -1,5 +1,6 @@
 <h1>New Page: <%= @page.title %></h1>
 <%= render partial: "page_form", locals: { page: @page } %>
 <div class="welcome">
-  Live Preview Here
+  <%= render partial: "shared/page_content", locals: { page: @page } %>
 </div>
+

--- a/app/views/shared/_page_content.html.erb
+++ b/app/views/shared/_page_content.html.erb
@@ -1,0 +1,6 @@
+<div class="page-content">
+  <div class="page-title text-left"><%= page.title %></div>
+  <div class="page-body text-left">
+    <%= MarkdownHelper.new(page.body).render %>
+  </div>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,6 @@
-<h1>Edit User Information</h1>
+<%= content_for :dialogue do %>
+  <h1>Edit User Information</h1>
+<% end %>
 
 <%= simple_form_for @user do |f| %>
   <%= f.input :domain %>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -2,10 +2,6 @@
   <ul class="page-view nav nav-stacked">
     <li><%= link_to "Menu", root_url %></li>
   </ul>
-  <div class="page-content">
-    <div class="page-title text-left"><%= @page.title %></div>
-    <div class="page-body text-left">
-      <%= MarkdownHelper.new(@page.body).render %>
-    </div>
-  </div>
+
+  <%= render partial: "shared/page_content", locals: { page: @page } %>
 </div>


### PR DESCRIPTION
- Use the same styling as the main menu on the edit index page to keep
  consistency when tabbing across the top menu
- Creates the concept of a "dialogue" that will sit between the top
  menu nav and the page content. This will have a min-height so the
  content does not jump up and down if it is absent
- Live preview matches end styling perfectly
  Using a partial to ensure the same wrapping markup (used mainly for
  name spacing css, e.g. `.welcome`, `.page-body`) is used in the
  preview and the actual pages that a user creates.
- Large devices should have some margin on the sides (using bootstrap
  col classes)
- Bootstrap columns used to make mobile/medium screen styling better so
  that the top menu items do not wrap