### PR TITLE
User decides whether page titles visible at root

### DIFF
--- a/app/controllers/concerns/welcome_controller.rb
+++ b/app/controllers/concerns/welcome_controller.rb
@@ -2,7 +2,7 @@ class WelcomeController < ApplicationController
   before_filter :ensure_domain_has_user!, only: [:show]
 
   def index
-    @pages = PageOrderer.new(user_by_domain).pages
+    @pages = PageOrderer.new(user_by_domain).visible_pages
   end
 
   def show

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -58,6 +58,6 @@ class PagesController < ApplicationController
   end
 
   def page_params
-    params.require(:page).permit(:title, :body, :order, :url_key)
+    params.require(:page).permit(:title, :body, :hidden, :order, :url_key)
   end
 end

--- a/app/models/page_orderer.rb
+++ b/app/models/page_orderer.rb
@@ -11,9 +11,25 @@ class PageOrderer
     end
   end
 
+  def visible_pages
+    if pages.blank?
+      []
+    else
+      pages.where(hidden: false)
+    end
+  end
+
   def next_page
     order = pages.any? ? pages.maximum(:order) + 1 : 1
     user.pages.new(order: order)
+  end
+
+  def page_after(page)
+    user.pages.find_by_order(page.order + 1) || pages.first
+  end
+
+  def page_before(page)
+    user.pages.find_by_order(page.order - 1) || pages.last
   end
 
   private

--- a/app/views/pages/_page_form.html.erb
+++ b/app/views/pages/_page_form.html.erb
@@ -2,6 +2,7 @@
   <%= f.input :title %>
   <%= f.input :body %>
   <%= f.input :order %>
+  <%= f.input :hidden, as: :select %>
   <%= f.input :url_key %>
   <%= f.submit class: "pull-left" %>
 <% end %>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -3,5 +3,18 @@
     <li><%= link_to "Menu", root_url %></li>
   </ul>
 
+  <div class="paginate clearfix">
+    <%= link_to(
+      "<",
+      "/#{ PageOrderer.new(user_by_domain).page_before(@page).url_key }",
+      class: "pull-left"
+    ) %>
+    <%= link_to(
+      ">",
+      "/#{ PageOrderer.new(user_by_domain).page_after(@page).url_key }",
+      class: "pull-right"
+    ) %>
+  </div>
+
   <%= render partial: "shared/page_content", locals: { page: @page } %>
 </div>

--- a/db/migrate/20151128190124_add_hidden_to_pages.rb
+++ b/db/migrate/20151128190124_add_hidden_to_pages.rb
@@ -1,0 +1,5 @@
+class AddHiddenToPages < ActiveRecord::Migration
+  def change
+    add_column :pages, :hidden, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151109001841) do
+ActiveRecord::Schema.define(version: 20151128190124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,11 +27,12 @@ ActiveRecord::Schema.define(version: 20151109001841) do
   create_table "pages", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "title",      default: "", null: false
-    t.text     "body",       default: "", null: false
-    t.integer  "order",                   null: false
+    t.string   "title",      default: "",    null: false
+    t.text     "body",       default: "",    null: false
+    t.integer  "order",                      null: false
     t.string   "url_key"
     t.integer  "user_id"
+    t.boolean  "hidden",     default: false
   end
 
   add_index "pages", ["user_id"], name: "index_pages_on_user_id", using: :btree

--- a/spec/features/pages/user_creates_a_page_spec.rb
+++ b/spec/features/pages/user_creates_a_page_spec.rb
@@ -30,10 +30,29 @@ feature "Creates a Page" do
     expect(page).to have_text("reserved")
   end
 
+  scenario "hidden page" do
+    user = create(:user)
+    domain = create(:domain, user: user)
+    set_host(domain.host)
+
+    visit new_page_url(as: user)
+    hidden_page = build(:page, hidden: true)
+    fill_in_fields(hidden_page)
+
+    expect(Page.last.title).to eq(hidden_page.title)
+
+    visit root_url
+    expect(page).not_to have_text(hidden_page.title)
+  end
+
   def fill_in_fields(page)
     fill_in "Title", with: page.title
     fill_in "Url Key", with: page.url_key
     fill_in "Body", with: page.body
+
+    option = page.hidden ? "Yes" : "No"
+    select option, from: "page_hidden"
+
     click_button "Create Page"
   end
 end

--- a/spec/models/page_orderer_spec.rb
+++ b/spec/models/page_orderer_spec.rb
@@ -44,4 +44,19 @@ describe PageOrderer do
       end
     end
   end
+
+  describe "page_after" do
+    it "returns the next page in order sequence or loops to beginning" do
+      user = create(:user)
+      create(:domain, user: user, host: "test")
+      first_page = create(:page, user: user)
+      second_page = create(:page, user: user)
+      third_page = create(:page, user: user)
+
+      page_orderer = PageOrderer.new(user.reload)
+
+      expect(page_orderer.page_after(second_page)).to eq(third_page)
+      expect(page_orderer.page_after(third_page)).to eq(first_page)
+    end
+  end
 end


### PR DESCRIPTION
* A column on pages determines whether the page is visible on the root
  page of the website
* This column is set when the page is created and can be edited later
* A link to the next page is provided on every page so that a user can
  view pages without returning to the main menu
* This feature could be tied together with projects a little better
  since it may be tiresome to create pages and remember the order
* For now this satisfies the client request of being able to view a
  sequence of photos

Need for
* swapping page order
* More efficient querying to get next/previous page (too many trips to
  db)
* Refactor tests/factories to set domain in less lines