### PR TITLE
Users can swap the order of pages on the root menu

### DIFF
--- a/app/controllers/order_swaps_controller.rb
+++ b/app/controllers/order_swaps_controller.rb
@@ -1,0 +1,22 @@
+class OrderSwapsController < ApplicationController
+  before_filter :authenticate_user!
+
+  def new
+    @pages = PageOrderer.new(current_user).pages
+  end
+
+  def create
+    if OrderSwap.new(order_swap_params, current_user).save
+      flash[:messages] = ["Order Swapped!"]
+    else
+      flash[:errors] = ["Failed to swap the order :( "]
+    end
+    redirect_to :back
+  end
+
+  private
+
+  def order_swap_params
+    params.require(:order_swap)
+  end
+end

--- a/app/models/order_keeper.rb
+++ b/app/models/order_keeper.rb
@@ -1,5 +1,0 @@
-class OrderKeeper
-  def initialize(pages)
-    @pages = pages
-  end
-end

--- a/app/models/order_swap.rb
+++ b/app/models/order_swap.rb
@@ -1,0 +1,32 @@
+class OrderSwap
+  def initialize(params, user)
+    @params = params
+    @user = user
+  end
+
+  def save
+    result = true
+    Page.transaction(requires_new: true) do
+      begin
+        pages.update_all(order: -1)
+        params.each do |id, order|
+          page = pages.find(id)
+          page.order = order
+          page.save!
+        end
+      rescue ActiveRecord::RecordInvalid
+        result = false
+        raise ActiveRecord::Rollback
+      end
+    end
+    result
+  end
+
+  private
+
+  def pages
+    @_pages ||= user.pages.where(id: params.keys)
+  end
+
+  attr_reader :params, :user
+end

--- a/app/views/order_swaps/new.html.erb
+++ b/app/views/order_swaps/new.html.erb
@@ -1,0 +1,12 @@
+<%= simple_form_for :order_swap, url: order_swaps_url do |f| %>
+  <% @pages.each do |page| %>
+    <%= f.input(
+      page.id,
+      label: page.title,
+      as: :select,
+      collection: @pages.pluck(:order),
+      selected: page.order
+    ) %>
+  <% end %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -17,6 +17,10 @@
       <li>
         <%= link_to "New Page", new_page_path  %>
       </li>
+
+      <li>
+        <%= link_to "Swap Order", new_order_swap_path  %>
+      </li>
     </ul>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
 
   resources :users, only: [:edit, :update]
 
+  resources :order_swaps, only: [:new, :create]
+
   get "/:url_key" => "welcome#show"
 
   get "projects/crop/:id" => 'projects#crop'

--- a/spec/features/pages/user_swaps_page_order_spec.rb
+++ b/spec/features/pages/user_swaps_page_order_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+feature "User swaps page order" do
+  scenario "User correctly swaps order" do
+    user = create(:user)
+    domain = create(:domain, user: user)
+    set_host(domain.host)
+
+    page1 = create(:page, user: user, order: 1)
+    page2 = create(:page, user: user, order: 2)
+
+    visit new_order_swap_path(as: user)
+
+    select_order(page1, 2)
+    select_order(page2, 1)
+    click_button("Save Order swap")
+
+    expect(page1.reload.order).to eq(2)
+    expect(page2.reload.order).to eq(1)
+    expect(page).to have_text("Order Swapped!")
+  end
+
+  scenario "Same order selected twice" do
+    user = create(:user)
+    domain = create(:domain, user: user)
+    set_host(domain.host)
+
+    page1 = create(:page, user: user, order: 1)
+    page2 = create(:page, user: user, order: 2)
+
+    visit new_order_swap_path(as: user)
+
+    select_order(page1, 2)
+    # page2 order remains 2 as well
+    click_button("Save Order swap")
+
+    expect(page1.reload.order).to eq(1)
+    expect(page2.reload.order).to eq(2)
+    expect(page).to have_text("Failed")
+
+  end
+
+  def select_order(page, order)
+    find("#order_swap_#{page.id}").select(order)
+  end
+end

--- a/spec/models/order_swap_spec.rb
+++ b/spec/models/order_swap_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe OrderSwap do
+  describe ".save" do
+    it "returns true when it swaps orders successfully" do
+      user = create(:user)
+      page1 = create(:page, user: user, order: 1)
+      page2 = create(:page, user: user, order: 2)
+      swap_params = { page1.id => page2.order, page2.id => page1.order }
+
+      order_swap = OrderSwap.new(swap_params, user)
+
+      expect(order_swap.save).to eq(true)
+      expect(page1.reload.order).to eq(2)
+      expect(page2.reload.order).to eq(1)
+    end
+
+    it "handles bad data" do
+      user = create(:user)
+      page1 = create(:page, user: user, order: 1)
+      page2 = create(:page, user: user, order: 2)
+      swap_params = { page1.id => 3, page2.id => 3 }
+
+      order_swap = OrderSwap.new(swap_params, user)
+
+      expect(order_swap.save).to eq(false)
+      expect(page1.reload.order).to eq(1)
+      expect(page2.reload.order).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Currently each page has a persisted attribute `order` that determines
where it appears on the root menu. Now users can modify this attribute
after a page is created. The unique constraint on page.order requires
a number of calls to the database to swap the order of pages. First, all
page orders are set to -1 (skipping rails validations). Then pages are
ordered based on user input. This means every page is re-saved even if
the order remained the same.

Quick and dirty... optimize later

The abovementioned process is wrapped in a transaction so the original
state can be preserved if other errors occur.

TIL: since tests are wrapped in a transaction:
http://stackoverflow.com/questions/21340686/rails-transaction-not-rolling-back
need to pass the `requires_new: true` since this is a nested transaction
in when running a test:
http://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html