### PR TITLE
Stylistic changes

### DIFF
--- a/app/assets/stylesheets/shared/base.scss
+++ b/app/assets/stylesheets/shared/base.scss
@@ -1,5 +1,5 @@
 @import "shared/mixins";
-$font-size: 30px;
+@import "shared/variables";
 
 div,
 p,
@@ -15,4 +15,11 @@ input,
 
 h1 {
   text-align: center;
+}
+
+.new-action {
+  color: $new-green;
+  &:hover {
+    color: $new-green-darker;
+  }
 }

--- a/app/assets/stylesheets/shared/variables.scss
+++ b/app/assets/stylesheets/shared/variables.scss
@@ -1,3 +1,6 @@
 $desktop-screen: "only screen and (min-width: 601px)" !default;
+$font-size: 30px;
 $text-size: 65px;
 $devise-pink: #F2DEDE;
+$new-green: #008000;
+$new-green-darker: #006400;

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,6 +1,6 @@
 <div class="edit-index">
   <%= content_for :dialogue do %>
-    <h1>Click to Edit</h1>
+    <h1>Click a page to edit</h1>
   <% end %>
 
   <div class="welcome container-fluid">
@@ -14,12 +14,18 @@
         </li>
       <% end %>
 
+      <h1>Other options</h1>
+
       <li>
-        <%= link_to "New Page", new_page_path  %>
+        <%= link_to "Add a new page", new_page_path, class: "new-action" %>
       </li>
 
       <li>
-        <%= link_to "Swap Order", new_order_swap_path  %>
+        <%= link_to(
+          "Swap order",
+          new_order_swap_path,
+          class: "new-action"  
+        ) %>
       </li>
     </ul>
   </div>

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -1,5 +1,9 @@
-<h1>New Page: <%= @page.title %></h1>
+<%= content_for :dialogue do %>
+  <h1>New Page: <%= @page.title %></h1>
+<% end %>
+
 <%= render partial: "page_form", locals: { page: @page } %>
+
 <div class="welcome">
   <%= render partial: "shared/page_content", locals: { page: @page } %>
 </div>

--- a/spec/features/pages/user_creates_a_page_spec.rb
+++ b/spec/features/pages/user_creates_a_page_spec.rb
@@ -6,7 +6,7 @@ feature "Creates a Page" do
     visit root_url(as: user)
 
     click_link "Edit Menu"
-    click_link "New Page"
+    click_link "Add a new page"
 
     unsaved_page = build(:page)
     fill_in_fields(unsaved_page)


### PR DESCRIPTION
Editing pages is an option from the user menu, but adding a new page and
swapping the order of pages are require links somewhere. These options
will be links once this option is clicked. They appear green so they
stand out, and it is clear they are not pages to be edited.

* Also fix styling bug where the new page form had too much margin above
  it.