### PR TITLE
Prevent hidden pages from being scrolled through

### DIFF
--- a/app/models/page_orderer.rb
+++ b/app/models/page_orderer.rb
@@ -20,19 +20,25 @@ class PageOrderer
   end
 
   def next_page
-    order = pages.any? ? pages.maximum(:order) + 1 : 1
+    order = visible_pages.any? ? pages.maximum(:order) + 1 : 1
     user.pages.new(order: order)
   end
 
   def page_after(page)
-    user.pages.find_by_order(page.order + 1) || pages.first
+    ordered_pages.where("pages.order > ?", page.order).first ||
+      ordered_pages.first
   end
 
   def page_before(page)
-    user.pages.find_by_order(page.order - 1) || pages.last
+    ordered_pages.where("pages.order < ?", page.order).last ||
+      ordered_pages.last
   end
 
   private
 
   attr_reader :user
+
+  def ordered_pages
+    @ordered_pages ||= visible_pages.order(:order)
+  end
 end

--- a/spec/features/pages/user_clicks_through_pages_spec.rb
+++ b/spec/features/pages/user_clicks_through_pages_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+feature "User navigates through pages" do
+  scenario do
+    user = user_at_test_domain
+    first_page = create(:page, user: user, body: "first")
+    second_page = create(:page, user: user, body: "second")
+    third_page = create(:page, user: user, body: "third")
+    fourth_hidden_page = create(:page, user: user, body: "fourth", hidden: true)
+
+    visit root_url
+
+    click_link(first_page.title)
+    expect(page).to have_text(first_page.body)
+    click_link(">")
+    expect(page).to have_text(second_page.body)
+    click_link(">")
+    expect(page).to have_text(third_page.body)
+    click_link(">")
+    expect(page).to have_text(first_page.body)
+    expect(page).not_to have_text(fourth_hidden_page.body)
+
+    visit "/#{fourth_hidden_page.url_key}"
+    expect(page).to have_text(fourth_hidden_page.body)
+  end
+end

--- a/spec/models/page_orderer_spec.rb
+++ b/spec/models/page_orderer_spec.rb
@@ -58,5 +58,17 @@ describe PageOrderer do
       expect(page_orderer.page_after(second_page)).to eq(third_page)
       expect(page_orderer.page_after(third_page)).to eq(first_page)
     end
+
+    it "ignores hidden pages" do
+      user = create(:user)
+      create(:domain, user: user, host: "test")
+      first_page = create(:page, user: user)
+      _second_page_hidden = create(:page, user: user, hidden: true)
+      third_page = create(:page, user: user)
+
+      page_orderer = PageOrderer.new(user.reload)
+
+      expect(page_orderer.page_after(first_page)).to eq(third_page)
+    end
   end
 end


### PR DESCRIPTION
This allows pages to exist that will not be found unless the url_key is
known or guessed. Previously, the page could be hidden from the root
url, but if one clicked "next" or "back" (</>) the page would be found.

Use case: I put up a weird page at `/secret-page` and I do not want it
to be found if someone visits the website and scrolls through pages by
clicking next: ">"