### PR TITLE
Re-map associations for users/domains/pages/photos

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -1,5 +1,8 @@
 class Domain < ActiveRecord::Base
   belongs_to :user
+  has_many :projects, dependent: :destroy
+  has_many :pages, dependent: :destroy
+  has_many :photos, through: :projects
 
   validates :host, uniqueness: true, presence: true
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,13 +5,14 @@ class Page < ActiveRecord::Base
 
   validates :title, presence: true
   validates :body, presence: true
-  validates :order, presence: true, uniqueness: { scope: :user_id }
+  validates :order, presence: true, uniqueness: { scope: :domain_id }
   validates(
     :url_key,
     presence: true,
-    uniqueness: { scope: :user_id },
+    uniqueness: { scope: :domain_id },
     exclusion: { in: RESERVED_WORDS }
   )
 
+  belongs_to :domain
   belongs_to :user
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,6 +5,7 @@ class Project < ActiveRecord::Base
   validates :url_key, presence: true, uniqueness: { scope: :user_id }
 
   belongs_to :user
+  belongs_to :domain
 
   has_many :photos, dependent: :destroy
   accepts_nested_attributes_for :photos

--- a/db/migrate/20160704190325_add_domain_id_to_other_tables.rb
+++ b/db/migrate/20160704190325_add_domain_id_to_other_tables.rb
@@ -1,0 +1,7 @@
+class AddDomainIdToOtherTables < ActiveRecord::Migration
+  def change
+    add_column :pages, :domain_id, :integer
+    add_column :projects, :domain_id, :integer
+    add_column :photos, :domain_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151128190124) do
+ActiveRecord::Schema.define(version: 20160704190325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20151128190124) do
     t.string   "url_key"
     t.integer  "user_id"
     t.boolean  "hidden",     default: false
+    t.integer  "domain_id"
   end
 
   add_index "pages", ["user_id"], name: "index_pages_on_user_id", using: :btree
@@ -45,6 +46,7 @@ ActiveRecord::Schema.define(version: 20151128190124) do
     t.string   "avatar_content_type"
     t.integer  "avatar_file_size"
     t.datetime "avatar_updated_at"
+    t.integer  "domain_id"
   end
 
   create_table "projects", force: :cascade do |t|
@@ -63,6 +65,7 @@ ActiveRecord::Schema.define(version: 20151128190124) do
     t.datetime "avatar_updated_at"
     t.integer  "user_id"
     t.string   "url_key"
+    t.integer  "domain_id"
   end
 
   add_index "projects", ["user_id"], name: "index_projects_on_user_id", using: :btree

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -6,32 +6,32 @@ describe Page do
   it { should validate_presence_of(:order) }
   it { should validate_uniqueness_of(:order) }
   it { should validate_presence_of(:url_key) }
-  it { should belong_to :user }
+  it { should belong_to :domain }
 
   describe "unique url_keys" do
-    it "does not allow user to have a page with same url key" do
-      user = create(:user)
-      user_2 = create(:user)
+    it "does not allow a domain to have a page with same url key" do
+      domain = create(:domain)
+      domain_2 = create(:domain)
 
-      create(:page, url_key: "test", user: user)
-      page = build(:page, url_key: "test", user: user)
+      create(:page, url_key: "test", domain: domain)
+      page = build(:page, url_key: "test", domain: domain)
 
       expect(page).to_not be_valid
 
-      page.user = user_2
+      page.domain = domain_2
       expect(page).to be_valid
     end
 
     it "does not allow pages to have the same order" do
-      user = create(:user)
-      user_2 = create(:user)
+      domain = create(:domain)
+      domain_2 = create(:domain)
 
-      create(:page, user: user, order: 1)
-      page = build(:page, user: user, order: 1)
+      create(:page, domain: domain, order: 1)
+      page = build(:page, domain: domain, order: 1)
 
       expect(page).to_not be_valid
 
-      page.user = user_2
+      page.domain = domain_2
       expect(page).to be_valid
     end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe Project do
   it { should belong_to :user }
+  it { should belong_to :domain }
   it { should validate_uniqueness_of(:url_key) }
   it { should validate_presence_of(:url_key) }
   it { should validate_presence_of(:title) }


### PR DESCRIPTION
* Most of these models should be tied with a domain rather than a user.
  This way a user can own multiple domains.
* This also allows simple niceties uploading photos without creating a
  "project" and then finding that project to get the photo url. This
  will prevent some of the silly work arounds users of this website
  perform

STEPS COMPLETED HERE:
* Database changes: add foreign key columns. Update tests for
* associations to tie domain with other models.
NEXT STEPS:
* Rake task to map projects/photos/pages to domains owned by a user
  (next PR)
* Change code to display the same thing, but with domain used in the
  place of users throughout code
* One remove old code tying these things to users (associations)
* Create more convenient features lik uploading photos without projects

Alternative:
* A new data model (e.g. website) could be used since multiple domains
  could share the same content. This seems like overkill, and it would
  be easy enough to rename the `domains` table later anyway.