### PR TITLE
Adds rake task to associate models with domains

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -2,6 +2,7 @@ class Photo < ActiveRecord::Base
   include AttachAvatar
   include Croppable
   belongs_to :project
+  belongs_to :domain
   has_one :user, through: :project
 
   def suggested_photo_based_on_size

--- a/app/services/migrate_content.rb
+++ b/app/services/migrate_content.rb
@@ -1,0 +1,19 @@
+class MigrateContent
+  MODEL_CLASS = [Page, Project, Photo].freeze
+
+  class << self
+    def run
+      MODEL_CLASS.each do |model_class|
+        update_domains_for(model_class)
+      end
+    end
+
+    private
+
+    def update_domains_for(model_class)
+      model_class.all.each do |model|
+        model.update!(domain: model.user.domains.first)
+      end
+    end
+  end
+end

--- a/lib/tasks/migrate_content.rake
+++ b/lib/tasks/migrate_content.rake
@@ -1,0 +1,5 @@
+namespace :migrate_content do
+  task :run => :environment do
+    MigrateContent.run
+  end
+end

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+describe Photo do
+  it { should belong_to :domain }
+end

--- a/spec/services/migrate_content_spec.rb
+++ b/spec/services/migrate_content_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe MigrateContent do
+  describe ".run" do
+    it "associates models with a users first domain" do
+      user = create(:user)
+      domain = create(:domain, user: user)
+      page = create(:page, user: user)
+      project = create(:project, user: user)
+      photo = create(:photo, project: project)
+
+      MigrateContent.run
+      page.reload
+      photo.reload
+      project.reload
+
+      expect(page.domain).to eq(domain)
+      expect(project.domain).to eq(domain)
+      expect(photo.domain).to eq(domain)
+    end
+  end
+end


### PR DESCRIPTION
* The three models (pages, photos, and projects) should belong to a
  domain rather than a user. This way domains can be transfered between
  accounts.
* This associates the existing models to each model's user's first
  domain. Users without domains have been removed from production.
* Page/Project simply belong to a user, but a photo belongs to a project
  which has_one user. The necessary rails association has been added to
  allow the same generic code to work for all models: `model.domain =
  model.user.domains.first` (a user has many photos through projects)
* Photo spec added