### PR TITLE
Create current_user_domain method

### DIFF
--- a/app/controllers/concerns/application_controller.rb
+++ b/app/controllers/concerns/application_controller.rb
@@ -9,6 +9,10 @@ class ApplicationController < ActionController::Base
     @user_by_domain ||= domain.try(:user)
   end
 
+  def current_user_domain
+    current_user && current_user.domains.where(host: request.host).first
+  end
+
   def domain
     @domain ||= Domain.find_by_host(request.host)
   end
@@ -17,5 +21,10 @@ class ApplicationController < ActionController::Base
     domain.try(:page_title) || "Adrian Rules"
   end
 
-  helper_method :ensure_domain_has_user!, :user_by_domain, :page_title
+  helper_method(
+    :current_user_domain,
+    :ensure_domain_has_user!,
+    :user_by_domain,
+    :page_title
+  )
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 describe ApplicationController do
-  let(:current_domain) { "test.host" }
+  include AuthHelper
+  let(:current_host) { "test.host" }
 
   describe ".page_title" do
     controller do
@@ -17,7 +18,7 @@ describe ApplicationController do
     end
 
     it "returns the domains page title" do
-      create(:domain, host: current_domain, page_title: "My Title")
+      create(:domain, host: current_host, page_title: "My Title")
       get :index
 
       expect(response.body).to eq("My Title")
@@ -31,13 +32,50 @@ describe ApplicationController do
       end
     end
 
-    it "finds the user assoicated with the current_domain" do
+    it "finds the user assoicated with the current_host" do
       user = create(:user)
-      create(:domain, user: user, host: current_domain)
+      create(:domain, user: user, host: current_host)
 
       get :index
 
       expect(response.body).to eq(user.email)
+    end
+  end
+
+  describe ".current_user_domain" do
+    controller do
+      def index
+        render text: current_user_domain.try(:host)
+      end
+    end
+
+    it "returns nil if current_user is nil" do
+      stub_current_user(nil)
+
+      get :index
+
+      expect(response.body).to eq("")
+    end
+
+    it "returns nil if current_user does not own the domain" do
+      bob = create(:user)
+      steve = create(:user)
+      create(:domain, host: current_host, user: steve)
+      stub_current_user(bob)
+
+      get :index
+
+      expect(response.body).to eq("")
+    end
+
+    it "returns the current_user's domain" do
+      user = create(:user)
+      domain = create(:domain, user: user, host: current_host)
+      stub_current_user(user)
+
+      get :index
+
+      expect(response.body).to eq(domain.host)
     end
   end
 end

--- a/spec/controllers/auth_helper.rb
+++ b/spec/controllers/auth_helper.rb
@@ -1,4 +1,11 @@
-def sign_in_and_stub(user)
-  sign_in :user, user
-  allow(controller).to receive(:user_by_domain) { user }
+module AuthHelper
+  def sign_in_and_stub(user)
+    sign_in :user, user
+    allow(controller).to receive(:user_by_domain) { user }
+  end
+
+  def stub_current_user(user)
+    allow(request.env["warden"]).to receive(:authenticate!).and_return(user)
+    allow(controller).to receive(:current_user).and_return(user)
+  end
 end

--- a/spec/controllers/pages_conroller_spec.rb
+++ b/spec/controllers/pages_conroller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe PagesController do
+  include AuthHelper
+
   before do
     @user = create(:user)
     create(:domain, host: "test.host")

--- a/spec/controllers/photos_controller_spec.rb
+++ b/spec/controllers/photos_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe PhotosController do
+  include AuthHelper
+
   def set_http_referrer
     request.env["HTTP_REFERER"] = "www.some_project.url"
   end


### PR DESCRIPTION
* This method will replace current_user for this app. Applications that
  use devise follow the helpful practice of creating new objects through
  an association using the rails pattern `current_user.pages.new` that
  causes the new model to be instantiated with user_id set. In this
  application we want content tied to domains rather than users.
* The name `current_domain` could also work, but `current_user_domain`
  makes it a bit more clear that this depends on current_user

* The hack for testing controller methods (rendering the text and then
  looking at the response body) feels very silly. This should probably
  pulled into a class and wrapped in a module, but unfortunately I
  learned rails before I learned good object oriented design. Sorry.
https://github.com/plataformatec/devise/wiki/How-To:-Stub-authentication-in-controller-specs