### PR TITLE
Move navigating links to either side of the menu

### DIFF
--- a/app/assets/stylesheets/welcome.css.scss
+++ b/app/assets/stylesheets/welcome.css.scss
@@ -11,6 +11,10 @@
     @include text-sizing($text-size, 1.0);
   }
 
+  div a {
+    display: block;
+  }
+
   li a {
     display:block;
   }

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -1,20 +1,19 @@
-<div class="welcome container-fluid">
-  <ul class="page-view nav nav-stacked">
-    <li><%= link_to "Menu", root_url %></li>
-  </ul>
-
-  <div class="paginate clearfix">
+<div class="welcome container-fluid nav">
+  <li class="col-xs-4">
     <%= link_to(
-      "<",
-      "/#{ PageOrderer.new(domain).page_before(@page).url_key }",
-      class: "pull-left"
+      "&lt;".html_safe,
+      "/#{ PageOrderer.new(domain).page_before(@page).url_key }"
     ) %>
+  </li>
+  <li class="col-xs-4">
+    <%= link_to "Menu", root_url %>
+  </li>
+  <li class="col-xs-4">
     <%= link_to(
-      ">",
-      "/#{ PageOrderer.new(domain).page_after(@page).url_key }",
-      class: "pull-right"
+      "&gt;".html_safe,
+      "/#{ PageOrderer.new(domain).page_after(@page).url_key }"
     ) %>
-  </div>
+  </li>
 
   <%= render partial: "shared/page_content", locals: { page: @page } %>
 </div>


### PR DESCRIPTION
* I wish I used bourbon instead of boostrap :(
* Can't use nav-justified and nav-tabs for these because the mobile view
  will be stacked
* probably should have used those for the rest of the menu though. Too
  much done by hand
* Text "menu" too large on mobile so hovering looks bad, but will leave
  it for now

before
<img width="1172" alt="screen shot 2016-07-10 at 1 43 43 pm" src="https://cloud.githubusercontent.com/assets/6473009/16715079/6142976a-46a4-11e6-85fe-bc09fb05a67f.png">


after
<img width="1173" alt="screen shot 2016-07-10 at 1 43 37 pm" src="https://cloud.githubusercontent.com/assets/6473009/16715080/66771a6c-46a4-11e6-9c66-2e8ce1e27f35.png">

