### PR TITLE
Users can customize the root page

### DIFF
--- a/app/views/meta_property_lists/_form.html.erb
+++ b/app/views/meta_property_lists/_form.html.erb
@@ -1,0 +1,7 @@
+<%= simple_form_for meta_property_list do |f| %>
+  <%= f.input :og_image %>
+  <%= f.input :og_title %>
+  <%= f.input :og_url %>
+  <%= f.input :root_content %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/meta_property_lists/edit.html.erb
+++ b/app/views/meta_property_lists/edit.html.erb
@@ -1,6 +1,4 @@
-<%= simple_form_for @meta_property_list do |f| %>
-  <%= f.input :og_image %>
-  <%= f.input :og_title %>
-  <%= f.input :og_url %>
-  <%= f.submit "Update" %>
-<% end %>
+<%= render(
+  partial: "form",
+  locals: { meta_property_list: @meta_property_list}
+) %>

--- a/app/views/meta_property_lists/new.html.erb
+++ b/app/views/meta_property_lists/new.html.erb
@@ -1,6 +1,4 @@
-<%= simple_form_for @meta_property_list do |f| %>
-  <%= f.input :og_image %>
-  <%= f.input :og_title %>
-  <%= f.input :og_url %>
-  <%= f.submit "Create" %>
-<% end %>
+<%= render(
+  partial: "form",
+  locals: { meta_property_list: @meta_property_list}
+) %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,9 +1,13 @@
 <div class="welcome container-fluid">
-  <ul class="pages nav nav-stacked">
-    <% @pages.each do |page| %>
-      <li>
-        <%= link_to page.title, page.url_key %>
-      </li>
-    <% end %>
-  </ul>
+  <% if domain.meta_property_list.try(:root_content).present? %>
+    <%= MarkdownHelper.new(domain.meta_property_list.root_content).render %>
+  <% else %>
+    <ul class="pages nav nav-stacked">
+      <% @pages.each do |page| %>
+        <li>
+          <%= link_to page.title, page.url_key %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
 </div>

--- a/spec/features/meta_property_list/user_creates_root_content_spec.rb
+++ b/spec/features/meta_property_list/user_creates_root_content_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+feature "User creates root content" do
+  scenario "no content on home page" do
+    user = create(:user)
+    domain = create(:domain, user: user)
+    set_host(domain.host)
+
+    visit root_path
+
+    expect(page).to_not have_text("Oh my root")
+
+    visit new_meta_property_list_path(as: user)
+
+    fill_in "Root content", with: "Oh my root"
+    click_button "Create"
+
+    visit root_url
+
+    expect(page).to have_text("Oh my root")
+  end
+end


### PR DESCRIPTION
* It does not need to be the stacked menu of pages.
* If the root_content field of the meta_property_list tied to a domain
  is blank, the menu of pages will be shown as usual. Otherwise, the
  root content will show.
* Use partial for meta_property_list form used on new and edit pages