### PR TITLE
Add live preview to root_content form

### DIFF
--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -1,6 +1,6 @@
 $(function(){
-  var $message = $("#page_body");
-  var $previewBox = $(".page-body");
+  var $message = $(".preview-message");
+  var $previewBox = $(".preview-box");
   var previewPlaceholder = $previewBox.html()
   var lastResponseMarkdown = previewPlaceholder;
   var lastTextSent = $message.val();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,6 @@
   <head>
     <title><%= page_title %></title>
     <%= stylesheet_link_tag    "application", media: "all" %>
-    <%= stylesheet_link_tag "application", params[:controller], :media => "all" %>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
     <%= favicon_link_tag "favicon.png" %>

--- a/app/views/meta_property_lists/_form.html.erb
+++ b/app/views/meta_property_lists/_form.html.erb
@@ -2,6 +2,10 @@
   <%= f.input :og_image %>
   <%= f.input :og_title %>
   <%= f.input :og_url %>
-  <%= f.input :root_content %>
+  <%= f.input :root_content, input_html: { class: "preview-message" } %>
   <%= f.submit %>
 <% end %>
+
+<div class="welcome container-fluid">
+  <div class="preview-box"></div>
+</div>

--- a/app/views/pages/_page_form.html.erb
+++ b/app/views/pages/_page_form.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for(page) do |f| %>
   <%= f.input :title %>
-  <%= f.input :body %>
+  <%= f.input :body, input_html: { class: "preview-message" } %>
   <%= f.input :order %>
   <%= f.input :hidden, as: :select %>
   <%= f.input :url_key %>

--- a/app/views/shared/_page_content.html.erb
+++ b/app/views/shared/_page_content.html.erb
@@ -1,6 +1,6 @@
 <div class="page-content">
   <div class="page-title text-left"><%= page.title %></div>
-  <div class="page-body text-left">
+  <div class="page-body preview-box text-left">
     <%= MarkdownHelper.new(page.body).render %>
   </div>
 </div>

--- a/spec/features/meta_property_list/user_creates_root_content_spec.rb
+++ b/spec/features/meta_property_list/user_creates_root_content_spec.rb
@@ -1,22 +1,29 @@
 require "rails_helper"
 
-feature "User creates root content" do
+feature "User creates root content", js: true do
   scenario "no content on home page" do
+    clear_host_settings
     user = create(:user)
-    domain = create(:domain, user: user)
-    set_host(domain.host)
+    create(:domain, user: user, host: "127.0.0.1")
 
     visit root_path
 
-    expect(page).to_not have_text("Oh my root")
+    expect(page).to_not have_css("h1", text: "Oh my root")
 
     visit new_meta_property_list_path(as: user)
 
-    fill_in "Root content", with: "Oh my root"
+    fill_in "Root content", with: "<h1>Oh my root<h1>"
     click_button "Create"
 
-    visit root_url
+    visit root_path
 
-    expect(page).to have_text("Oh my root")
+    expect(page).to have_css("h1", text: "Oh my root")
+  end
+
+  private
+
+  def clear_host_settings
+    default_url_options[:host] = "www.example.com"
+    Capybara.app_host = nil
   end
 end


### PR DESCRIPTION
* Allow a preview of the markdown that will be generated for the front
  page (root page). Have feature spec test for markdown rendered html
  rather than plain text.
* Makes preview.js more generic. Simply add a class to a form element
  and it will denote the area to listen to for changes and the preview
  markup will be injected
* No need for including controller specific js since every js file is
  included everywhere
* Keep consistent styling with preview for root page content and the
  live preview (requires wrapping in welcome page div for now).

To do:
* Refactor out setup for capybara feature specs that require JS host to
  be set (method copied and pasted)
* Do not include all js everywhere (maybe only for logged in users)