### PR TITLE
Refactor out some common test setup code

### DIFF
--- a/spec/features/meta_property_list/user_creates_root_content_spec.rb
+++ b/spec/features/meta_property_list/user_creates_root_content_spec.rb
@@ -19,11 +19,4 @@ feature "User creates root content", js: true do
 
     expect(page).to have_css("h1", text: "Oh my root")
   end
-
-  private
-
-  def clear_host_settings
-    default_url_options[:host] = "www.example.com"
-    Capybara.app_host = nil
-  end
 end

--- a/spec/features/pages/user_sees_markdown_preview_spec.rb
+++ b/spec/features/pages/user_sees_markdown_preview_spec.rb
@@ -12,9 +12,4 @@ feature "Makrdown Preview", js: true do
 
     expect(page).to have_link("google")
   end
-
-  def clear_host_settings
-    default_url_options[:host] = "www.example.com"
-    Capybara.app_host = nil
-  end
 end

--- a/spec/support/host_helper.rb
+++ b/spec/support/host_helper.rb
@@ -1,4 +1,9 @@
 module HostHelper
+  def clear_host_settings
+    default_url_options[:host] = "www.example.com"
+    Capybara.app_host = nil
+  end
+
   def set_host(host)
     default_url_options[:host] = host
     Capybara.app_host = "http://" + host


### PR DESCRIPTION
JS feature specs require some specific host settings to match domains.
There may be a better, more concise way than this. One cannot use a
before hook in the rspec config block (js does not seem to execute then)