### PR TITLE
Style photo upload button

### DIFF
--- a/app/assets/stylesheets/shared/base.scss
+++ b/app/assets/stylesheets/shared/base.scss
@@ -1,5 +1,7 @@
 @import "shared/mixins";
+@import "shared/colors";
 @import "shared/variables";
+@import "shared/file_upload";
 
 div,
 p,

--- a/app/assets/stylesheets/shared/colors.css.scss
+++ b/app/assets/stylesheets/shared/colors.css.scss
@@ -1,0 +1,6 @@
+$gray: #808080;
+$white: #ffffff;
+$black: #000000;
+$devise-pink: #f2dede;
+$new-green: #008000;
+$new-green-darker: #006400;

--- a/app/assets/stylesheets/shared/file_upload.scss
+++ b/app/assets/stylesheets/shared/file_upload.scss
@@ -1,0 +1,26 @@
+.file {
+  input {
+    height: 0.1px;
+    opacity: 0;
+    overflow: hidden;
+    position: absolute;
+    width: 0.1px;
+    z-index: -1;
+  }
+
+  label {
+    background-color: $black;
+    border-radius: 3px;
+    color: $white;
+    cursor: pointer;
+    display: inline-block;
+    font-size: 1.25em;
+    font-weight: 700;
+    padding: 3px;
+
+    &:focus,
+    &:hover {
+      background-color: $gray;
+    }
+  }
+}

--- a/app/assets/stylesheets/shared/variables.scss
+++ b/app/assets/stylesheets/shared/variables.scss
@@ -1,6 +1,3 @@
 $desktop-screen: "only screen and (min-width: 601px)" !default;
 $font-size: 30px;
 $text-size: 65px;
-$devise-pink: #F2DEDE;
-$new-green: #008000;
-$new-green-darker: #006400;

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -3,7 +3,7 @@
   <%= f.input :description %>
   <%= f.input :url_key %>
 
-  <%= f.input :avatar, label: "Cover Photo" %>
+  <%= f.input :avatar, label: "Upload Cover Photo" %>
 
   <%= f.fields_for :photos do |ff| %>
     <%= ff.input :avatar %>


### PR DESCRIPTION
* Regression has caused no photo fields to be available below the cover
photo field. However, fixing that bug makes the ui confusing so that
will be done later. Photos can still be uploaded to an existing product
through the edit form (has a sensible ux)