### PR TITLE
Update Devise and fix deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,10 +30,8 @@ group :development do
   gem "bullet"
 end
 
-gem "backbone-on-rails"
-
-gem "paperclip"
-gem 'aws-sdk', '< 2.0'
+gem "paperclip", "~> 4.3.1"
+gem "aws-sdk", "~> 1.5.8"
 gem "dotenv-rails"
 
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,10 +38,6 @@ GEM
       activemodel (= 4.2.7.1)
       activesupport (= 4.2.7.1)
       arel (~> 6.0)
-    activeresource (4.0.0)
-      activemodel (~> 4.0)
-      activesupport (~> 4.0)
-      rails-observers (~> 0.1.1)
     activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -52,9 +48,8 @@ GEM
     airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.3)
-    autoprefixer-rails (6.0.3)
+    autoprefixer-rails (6.5.0.1)
       execjs
-      json
     autosize-rails (1.18.17)
       rails (>= 3.1)
     aws-sdk (1.5.8)
@@ -62,16 +57,7 @@ GEM
       json (~> 1.4)
       nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
-    backbone-on-rails (1.1.1.0)
-      actionmailer
-      actionpack
-      activemodel
-      activeresource
-      eco
-      ejs
-      jquery-rails
-      railties
-    bcrypt (3.1.10)
+    bcrypt (3.1.11)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -110,35 +96,24 @@ GEM
       json
     climate_control (0.0.3)
       activesupport (>= 3.0)
-    cocaine (0.5.7)
+    cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.1)
-    coffee-script (2.2.0)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.7.0)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
-    devise (3.5.1)
+    devise (4.2.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
+      railties (>= 4.1.0, < 5.1)
       responders
-      thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
-    dotenv (2.0.2)
-    dotenv-rails (2.0.2)
-      dotenv (= 2.0.2)
-      railties (~> 4.0)
-    eco (1.0.0)
-      coffee-script
-      eco-source
-      execjs
-    eco-source (1.1.0.rc.1)
-    ejs (1.1.1)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
-    execjs (2.2.1)
+    execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.7.0)
@@ -147,12 +122,12 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hike (1.2.3)
-    httparty (0.13.1)
-      json (~> 1.8)
+    httparty (0.14.0)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
-    jquery-rails (3.1.1)
-      railties (>= 3.0, < 5.0)
+    jquery-rails (4.2.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     launchy (2.4.3)
@@ -177,13 +152,13 @@ GEM
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
     orm_adapter (0.5.0)
-    paperclip (4.3.1)
+    paperclip (4.3.7)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (= 0.3.0)
-    pg (0.17.1)
+    pg (0.19.0)
     pkg-config (1.1.7)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -213,19 +188,17 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails-observers (0.1.2)
-      activemodel (~> 4.0)
     railties (4.2.7.1)
       actionpack (= 4.2.7.1)
       activesupport (= 4.2.7.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.3.0)
-    rdoc (4.1.1)
+    rdoc (4.2.2)
       json (~> 1.4)
-    redcarpet (3.2.2)
-    responders (2.1.0)
-      railties (>= 4.2.0, < 5)
+    redcarpet (3.3.4)
+    responders (2.3.0)
+      railties (>= 4.2.0, < 5.1)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -244,21 +217,21 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     sass (3.2.19)
-    sass-rails (4.0.3)
+    sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
-      sass (~> 3.2.0)
-      sprockets (~> 2.8, <= 2.11.0)
+      sass (~> 3.2.2)
+      sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
-    sdoc (0.4.0)
-      json (~> 1.8)
-      rdoc (~> 4.0, < 5.0)
+    sdoc (0.4.1)
+      json (~> 1.7, >= 1.7.7)
+      rdoc (~> 4.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
-    simple_form (3.1.0)
-      actionpack (~> 4.0)
-      activemodel (~> 4.0)
+    simple_form (3.3.1)
+      actionpack (> 4, < 5.1)
+      activemodel (> 4, < 5.1)
     slop (3.6.0)
-    sprockets (2.11.0)
+    sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -275,12 +248,11 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.5.1)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
+    uglifier (3.0.2)
+      execjs (>= 0.3.0, < 3)
     uniform_notifier (1.10.0)
-    uuidtools (2.1.4)
-    warden (1.2.3)
+    uuidtools (2.1.5)
+    warden (1.2.6)
       rack (>= 1.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -290,8 +262,7 @@ PLATFORMS
 
 DEPENDENCIES
   autosize-rails
-  aws-sdk (< 2.0)
-  backbone-on-rails
+  aws-sdk (~> 1.5.8)
   better_errors
   binding_of_caller
   bootstrap-sass
@@ -307,7 +278,7 @@ DEPENDENCIES
   factory_girl_rails
   jquery-rails
   launchy
-  paperclip
+  paperclip (~> 4.3.1)
   pg
   pry-rails
   rails

--- a/spec/controllers/auth_helper.rb
+++ b/spec/controllers/auth_helper.rb
@@ -1,6 +1,6 @@
 module AuthHelper
   def sign_in_and_stub(user)
-    sign_in :user, user
+    sign_in(user, scope: :user)
     allow(controller).to receive(:user_by_domain) { user }
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ RSpec.configure do |config|
   Rails.application.routes.default_url_options[:host] = 'localhost:3000'
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = false
-  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.include HostHelper, type: :feature
   config.infer_spec_type_from_file_location!
 end


### PR DESCRIPTION
* [Devise] including `Devise::TestHelpers` is deprecated
* [Devise] sign_in(:user, resource) on controller tests is deprecated

Also:
* Remove backbone-on-rails gem since backbone is no longer used
* Lock paperclip and aws-sdk at their current versions since these will
  need configuration and careful testing when they update. They should
  probably receive a major version bump. Some changes are related to SSL
  so this might be a good time to get a free cert.