### PR TITLE
Allow users to password protect a domain

### DIFF
--- a/app/controllers/concerns/application_controller.rb
+++ b/app/controllers/concerns/application_controller.rb
@@ -1,5 +1,10 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_filter :authenticate_protected_page!
+
+  def authenticate_protected_page!
+    authenticate_user! if protected_domain?
+  end
 
   def ensure_domain_has_user!
     redirect_to new_domain_url unless user_by_domain
@@ -29,4 +34,10 @@ class ApplicationController < ActionController::Base
     :user_by_domain,
     :page_title
   )
+
+  private
+
+  def protected_domain?
+    domain.try(:meta_property_list).try(:password_protected?)
+  end
 end

--- a/app/controllers/meta_property_lists_controller.rb
+++ b/app/controllers/meta_property_lists_controller.rb
@@ -46,6 +46,6 @@ class MetaPropertyListsController < ApplicationController
   def meta_property_list_params
     params.
       require(:meta_property_list).
-      permit(:og_image, :og_title, :og_url, :root_content)
+      permit(:og_image, :og_title, :og_url, :root_content, :password_protected)
   end
 end

--- a/app/views/meta_property_lists/_form.html.erb
+++ b/app/views/meta_property_lists/_form.html.erb
@@ -2,6 +2,7 @@
   <%= f.input :og_image %>
   <%= f.input :og_title %>
   <%= f.input :og_url %>
+  <%= f.input :password_protected, as: :select%>
   <%= f.input(
     :root_content,
     input_html: { class: "preview-message" },

--- a/db/migrate/20161108004458_add_password_protected_to_meta_property_list.rb
+++ b/db/migrate/20161108004458_add_password_protected_to_meta_property_list.rb
@@ -1,0 +1,10 @@
+class AddPasswordProtectedToMetaPropertyList < ActiveRecord::Migration
+  def change
+    add_column(
+      :meta_property_lists,
+      :password_protected,
+      :boolean,
+      default: false
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160708151115) do
+ActiveRecord::Schema.define(version: 20161108004458) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,8 +30,9 @@ ActiveRecord::Schema.define(version: 20160708151115) do
     t.string   "og_url"
     t.string   "og_title"
     t.text     "root_content"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
+    t.boolean  "password_protected", default: false
   end
 
   create_table "pages", force: :cascade do |t|

--- a/spec/features/user_hides_domain_with_password_spec.rb
+++ b/spec/features/user_hides_domain_with_password_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+feature "User hides domain with password" do
+  scenario "not presently hidden" do
+    user = create(:user)
+    domain = create(:domain, user: user)
+    create(:meta_property_list, domain: domain, password_protected: false)
+    set_host(domain.host)
+
+    visit new_meta_property_list_path(as: user)
+
+    select "Yes", from: "Password protected"
+
+    click_button "Update"
+
+    expect(page).to have_text("Success")
+
+    click_link "logout"
+
+    visit root_url
+    expect(page).to have_text("Sign in")
+  end
+end


### PR DESCRIPTION
* A certain friend requests their webpage be password protected.
* This means the entire website under one domain is off limits until the
  associated user flips the switch to turn it on.
* This switch is a boolean column on the meta property list which has a
  one-to-one relation ship with domains.
* This way a user can build a domain, and not allow it to be visible
  until the content is complete.
* The logic in ApplicationController is getting to be a bit too much. I
  need to look at commit messages to remember what each method is for
* To avoid chaining the `try` the MetaPropertyList association could be
  required. A NullObject pattern could be used as well.