### PR TITLE
Load images over https, force SSL for all pages

### DIFF
--- a/app/controllers/concerns/application_controller.rb
+++ b/app/controllers/concerns/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  force_ssl if: :ssl_configured?
   protect_from_forgery with: :exception
   before_filter :authenticate_protected_page!
 
@@ -34,6 +35,10 @@ class ApplicationController < ActionController::Base
     :user_by_domain,
     :page_title
   )
+
+  def ssl_configured?
+    Rails.env.production?
+  end
 
   private
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,11 +27,12 @@ module Maddie
     config.active_record.raise_in_transactional_callbacks = true
 
     config.paperclip_defaults = {
-      :storage => :s3,
-      :s3_credentials => {
-        :bucket => ENV["S3_BUCKET"],
-        :access_key_id => ENV["S3_ACCESS_KEY"],
-        :secret_access_key => ENV["S3_SECRET_KEY"]
+      s3_protocol: "https",
+      storage: :s3,
+      s3_credentials: {
+        bucket: ENV["S3_BUCKET"],
+        access_key_id: ENV["S3_ACCESS_KEY"],
+        secret_access_key: ENV["S3_SECRET_KEY"]
       }
     }
   end

--- a/lib/attach_avatar.rb
+++ b/lib/attach_avatar.rb
@@ -2,12 +2,13 @@ module AttachAvatar
   FILE_FORMATS = [/png\Z/, /jpe?g\Z/, /PNG\Z/, /JPE?G\Z/]
   THUMB = 100
   MEDIUM = 300
+  DEFAULT_URL = "https://s3.amazonaws.com/maddie_dev/photos/avatars/000/000/019/:style/search.jpg?1428163348".freeze
 
   def self.included(base)
     base.before_validation :make_url_image
     base.has_attached_file :avatar,
       processors: [:cropper],
-      default_url: "http://s3.amazonaws.com/maddie_dev/photos/avatars/000/000/019/:style/search.jpg?1428163348",
+      default_url: DEFAULT_URL,
       styles: {
         medium: "#{MEDIUM}x#{MEDIUM}>",
         thumb: "#{THUMB}x#{THUMB}>",


### PR DESCRIPTION
* AWS stored images are available over http/https, but it's best to
serve over https to avoid mixed content warnings. Also, I am forcing SSL
at the rails level until I can make the correct redirects in the NGINX
config files. Since this application has different content under each
domain, this requires some redundant config or that I understand NGINX a
bit better.